### PR TITLE
Allow processing of .gct.gz

### DIFF
--- a/R/cmap/io.R
+++ b/R/cmap/io.R
@@ -129,9 +129,9 @@ setMethod("initialize",
           signature = "GCT",
           definition = function(.Object, src, rid = NULL, cid = NULL, set_annot_rownames = T) {
               # check to make sure it's either .gct or .gctx
-              if (! (grepl(".gct$", src) || grepl(".gctx$", src) ))
+              if (! (grepl(".gct(\\.gz)?$", src) || grepl(".gctx(\\.gz)?$", src) ))
                   stop("Either a .gct or .gctx file must be given")
-              if (grepl(".gct$", src)) {
+              if (grepl(".gct(\\.gz)?$", src)) {
                   if ( ! is.null(rid) || !is.null(cid) )
                       stop("rid and cid values may only be given for .gctx files, not .gct files")
                   # parse the .gct


### PR DESCRIPTION
The files downloaded from [NCBI GEO](https://www.ncbi.nlm.nih.gov/geo/query/acc.cgi?acc=GSE70138) mostly come in `.gct.gz` format.

However, the R file loader `R/cmap/io.R` only supports matching the extension of `.gct`.

I can of course call `gunzip` on the file first. However, R is perfectly capable of doing this in memory alone without modifying the originally downloaded file.

I propose extending the extension matching to include an optional `.gz` after the `.gct` to allow for direct processing of the downloaded files.